### PR TITLE
fix no_std, no alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 [dependencies]
 # Arrayvec is only used if we require stack-allocation.
 # TODO(ahuszagh) Need to remove this dependency...
-arrayvec = { version = "0.4", optional = true, features = ["array-sizes-33-128"] }
+arrayvec = { version = "0.4", optional = true, default-features = false, features = ["array-sizes-33-128"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
nom 7 broke for me because I work in a no_std context, without an allocator. 
Arrayvec has the `std` feature enabled by default, so we need to disable the default features.