### PR TITLE
get rid of `no_alloc` feature, add `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ default = ["std"]
 std = []
 # Reduce code size at the cost of performance.
 compact = []
-# Do not use a system allocator anywhere.
-no_alloc = []
+# Use the system allocator.
+alloc = []
 # Add support for nightly-only features.
 nightly = []
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -18,9 +18,8 @@ fi
 # Test various feature combinations.
 FEATURES=(
     "compact"
-    # TODO(ahuszagh) Change to alloc.
-    "no_alloc"
-    "compact,no_alloc"
+    "alloc"
+    "compact,alloc"
 )
 
 check() {

--- a/etc/correctness/Cargo.toml
+++ b/etc/correctness/Cargo.toml
@@ -23,7 +23,7 @@ toml = "0.5"
 default = ["std"]
 std = ["minimal-lexical/std"]
 compact = ["minimal-lexical/compact"]
-no_alloc = ["minimal-lexical/no_alloc"]
+alloc = ["minimal-lexical/alloc"]
 nightly = ["minimal-lexical/nightly"]
 
 # Special testing binaries for the runtests.py scripts.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ libfuzzer-sys = "0.2.0"
 default = ["std"]
 std = ["minimal-lexical/std"]
 compact = ["minimal-lexical/compact"]
-no_alloc = ["minimal-lexical/no_alloc"]
+alloc = ["minimal-lexical/alloc"]
 nightly = ["minimal-lexical/nightly"]
 
 [profile.release]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -13,5 +13,5 @@ cd "$script_dir"/..
 cargo +nightly fmt -- --check
 cargo +nightly clippy --no-default-features -- --deny warnings
 cargo +nightly clippy --features=compact -- --deny warnings
-cargo +nightly clippy --features=no_alloc -- --deny warnings
+cargo +nightly clippy --features=alloc -- --deny warnings
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -4,10 +4,10 @@
 
 #![doc(hidden)]
 
-#[cfg(not(feature = "no_alloc"))]
+#[cfg(feature = "alloc")]
 use crate::heapvec::HeapVec;
 use crate::num::Float;
-#[cfg(feature = "no_alloc")]
+#[cfg(not(feature = "alloc"))]
 use crate::stackvec::StackVec;
 #[cfg(not(feature = "compact"))]
 use crate::table::{LARGE_POW5, LARGE_POW5_STEP};
@@ -23,10 +23,10 @@ pub const BIGINT_BITS: usize = 4000;
 /// The number of limbs for the bigint.
 pub const BIGINT_LIMBS: usize = BIGINT_BITS / LIMB_BITS;
 
-#[cfg(not(feature = "no_alloc"))]
+#[cfg(feature = "alloc")]
 pub type VecType = HeapVec;
 
-#[cfg(feature = "no_alloc")]
+#[cfg(not(feature = "alloc"))]
 pub type VecType = StackVec;
 
 /// Storage for a big integer type.

--- a/src/heapvec.rs
+++ b/src/heapvec.rs
@@ -1,6 +1,6 @@
 //! Simple heap-allocated vector.
 
-#![cfg(not(feature = "no_alloc"))]
+#![cfg(feature = "alloc")]
 #![doc(hidden)]
 
 use crate::bigint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 #![cfg_attr(feature = "lint", warn(unsafe_op_in_unsafe_fn))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(all(not(feature = "no_alloc"), not(feature = "std")))]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 
 pub mod bellerophon;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -134,7 +134,7 @@ where
 ///
 /// Although passing garbage input will not cause memory safety issues,
 /// it is very likely to cause a panic with a large number of digits, or
-/// in debug mode. The big-integer arithmetic with the `no_alloc` feature
+/// in debug mode. The big-integer arithmetic without the `alloc` feature
 /// assumes a maximum, fixed-width input, which assumes at maximum a
 /// value of `10^(769 + 342)`, or ~4000 bits of storage. Passing in
 /// nonsensical digits may require up to ~6000 bits of storage, which will

--- a/src/stackvec.rs
+++ b/src/stackvec.rs
@@ -1,6 +1,6 @@
 //! Simple stack-allocated vector.
 
-#![cfg(feature = "no_alloc")]
+#![cfg(not(feature = "alloc"))]
 #![doc(hidden)]
 
 use crate::bigint;

--- a/tests/stackvec.rs
+++ b/tests/stackvec.rs
@@ -1,7 +1,7 @@
 use minimal_lexical::bigint;
-#[cfg(not(feature = "no_alloc"))]
+#[cfg(feature = "alloc")]
 pub use minimal_lexical::heapvec::HeapVec as VecType;
-#[cfg(feature = "no_alloc")]
+#[cfg(not(feature = "alloc"))]
 pub use minimal_lexical::stackvec::StackVec as VecType;
 
 pub fn vec_from_u32(x: &[u32]) -> VecType {


### PR DESCRIPTION
I believe that this is the proper way to handle optional alloc/std features.
When using a crate with no default features enabled, it should assume the lowest common denominator. So, no allocator, no std. This PR makes that work.
Maybe this warrants a minor version increment, since we're changing the features?