### PR TITLE
Add LICENSE.md file with full license details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Missing license details for `src/bellerophon.rs`.
 
+## [0.2.0] 2021-09-10
+### Changed
+- `no_alloc` feature flag was replaced with an `alloc` feature flag.
+
 ## [0.1.3] 2021-09-04
 ### Added
 - Added the `compact` feature, which sacrifices performance for smaller binary sizes.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ Notes significant changes to minimal-lexical.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] 2021-10-02
+### Added
+- Missing license details for `src/bellerophon.rs`.
+
 ## [0.1.3] 2021-09-04
 ### Added
 - Added the `compact` feature, which sacrifices performance for smaller binary sizes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 name = "minimal-lexical"
 readme = "README.md"
 repository = "https://github.com/Alexhuszagh/minimal-lexical"
-version = "0.1.3"
+version = "0.1.4"
 exclude = [
     "assets/*",
     "ci/*",

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,37 @@
+Minimal-lexical is dual licensed under the Apache 2.0 license as well as the MIT
+license. See the LICENCE-MIT and the LICENCE-APACHE files for the licenses.
+
+---
+
+`src/bellerophon.rs` is loosely based off the Golang implementation,
+found [here](https://github.com/golang/go/blob/b10849fbb97a2244c086991b4623ae9f32c212d0/src/strconv/extfloat.go).
+That code (used if the `compact` feature is enabled) is subject to a
+[3-clause BSD license](https://github.com/golang/go/blob/b10849fbb97a2244c086991b4623ae9f32c212d0/LICENSE):
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ All changes are documented in [CHANGELOG](CHANGELOG).
 
 # License
 
-Minimal-lexical is dual licensed under the Apache 2.0 license as well as the MIT license. See the LICENCE-MIT and the LICENCE-APACHE files for the licenses. 
+Minimal-lexical is dual licensed under the Apache 2.0 license as well as the MIT
+license. See the [LICENSE.md](LICENSE.md) file for full license details.
 
 # Contributing
 


### PR DESCRIPTION
One of the crate files is subject to a 3-clause BSD license, which requires redistributing the license alongside the source code.

In order to enable downstream crates that depend on 0.1 series to benefit, I branched from the v0.1.3 tag, added the file, made a v0.1.4 commit, then merged in main. Assuming this is satisfactory, `minimal-lexical v0.1.4` can be published from the corresponding commit after this PR has been merged.

Closes #5.