### PR TITLE
Replace `Float::int_pow_fast_path` with a crate-private helper

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "alloc")]
 use crate::heapvec::HeapVec;
-use crate::num::Float;
+use crate::num::{int_pow_fast_path, FastPathRadix};
 #[cfg(not(feature = "alloc"))]
 use crate::stackvec::StackVec;
 #[cfg(not(feature = "compact"))]
@@ -395,7 +395,7 @@ pub fn pow(x: &mut VecType, mut exp: u32) -> Option<()> {
     }
     if exp != 0 {
         // SAFETY: safe, since `exp < small_step`.
-        let small_power = unsafe { f64::int_pow_fast_path(exp as usize, 5) };
+        let small_power = unsafe { int_pow_fast_path(exp as usize, FastPathRadix::Five) };
         small_mul(x, small_power as Limb)?;
     }
     Some(())

--- a/src/number.rs
+++ b/src/number.rs
@@ -7,7 +7,7 @@
 
 #[cfg(feature = "nightly")]
 use crate::fpu::set_precision;
-use crate::num::Float;
+use crate::num::{int_pow_fast_path, FastPathRadix, Float};
 
 /// Representation of a number as the significant digits and exponent.
 ///
@@ -68,7 +68,7 @@ impl Number {
                 // disguised fast path
                 let shift = self.exponent - max_exponent;
                 // SAFETY: safe, since `shift <= (max_disguised - max_exponent)`.
-                let int_power = unsafe { F::int_pow_fast_path(shift as usize, 10) };
+                let int_power = unsafe { int_pow_fast_path(shift as usize, FastPathRadix::Ten) };
                 let mantissa = self.mantissa.checked_mul(int_power)?;
                 if mantissa > F::MAX_MANTISSA_FAST_PATH {
                     return None;

--- a/src/slow.rs
+++ b/src/slow.rs
@@ -8,7 +8,7 @@
 
 use crate::bigint::{Bigint, Limb, LIMB_BITS};
 use crate::extended_float::{extended_to_float, ExtendedFloat};
-use crate::num::Float;
+use crate::num::{int_pow_fast_path, FastPathRadix, Float};
 use crate::number::Number;
 use crate::rounding::{round, round_down, round_nearest_tie_even};
 use core::cmp;
@@ -207,7 +207,7 @@ macro_rules! add_temporary {
     ($format:ident, $result:ident, $counter:ident, $value:ident) => {
         if $counter != 0 {
             // SAFETY: safe, since `counter <= step`, or smaller than the table size.
-            let small_power = unsafe { f64::int_pow_fast_path($counter, 10) };
+            let small_power = unsafe { int_pow_fast_path($counter, FastPathRadix::Ten) };
             add_temporary!(@mul $result, small_power as Limb, $value);
             $counter = 0;
             $value = 0;
@@ -222,7 +222,7 @@ macro_rules! add_temporary {
     (@end $format:ident, $result:ident, $counter:ident, $value:ident) => {
         if $counter != 0 {
             // SAFETY: safe, since `counter <= step`, or smaller than the table size.
-            let small_power = unsafe { f64::int_pow_fast_path($counter, 10) };
+            let small_power = unsafe { int_pow_fast_path($counter, FastPathRadix::Ten) };
             add_temporary!(@mul $result, small_power as Limb, $value);
         }
     };


### PR DESCRIPTION
Calling `Float::int_pow_fast_path` with a radix that was not 5 or 10
could result in UB by default. Now, we have an enum that prevents this
from occurring.

Closes Alexhuszagh/minimal-lexical#9.